### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,17 @@ include = [
 
 [features]
 default = ["bigint", "bitvec"]
-bigint = ["num"]
+bigint = ["num-bigint"]
 bitvec = ["bit-vec"]
 
-[dependencies]
-
-[dependencies.num]
+[dependencies.num-bigint]
 version = "0.1.32"
-features = ["bigint"]
+default-features = false
 optional = true
+
+[dev-dependencies.num-traits]
+version = "0.1.32"
+default-features = false
 
 [dependencies.bit-vec]
 version = "0.4.3"

--- a/src/deserializer/mod.rs
+++ b/src/deserializer/mod.rs
@@ -9,7 +9,7 @@
 use std::hash::Hash;
 
 #[cfg(feature = "bigint")]
-use num::bigint::{BigInt,BigUint};
+use num_bigint::{BigInt,BigUint};
 #[cfg(feature = "bitvec")]
 use bit_vec::BitVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,10 @@
 //! ```
 
 #[cfg(feature = "bigint")]
-extern crate num;
+extern crate num_bigint;
+#[cfg(test)]
+extern crate num_traits;
+
 #[cfg(feature = "bitvec")]
 extern crate bit_vec;
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -9,7 +9,7 @@
 mod error;
 
 #[cfg(feature = "bigint")]
-use num::bigint::{BigInt,BigUint,Sign};
+use num_bigint::{BigInt,BigUint,Sign};
 #[cfg(feature = "bitvec")]
 use bit_vec::BitVec;
 
@@ -593,11 +593,11 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num;
+    /// # extern crate num_bigint;
     /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
-    /// use num::bigint::BigInt;
+    /// use num_bigint::BigInt;
     /// let data = &[2, 4, 73, 150, 2, 210];
     /// let asn = yasna::parse_der(data, |reader| {
     ///     reader.read_bigint()

--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 #[cfg(feature = "bigint")]
-use num::bigint::{BigUint, BigInt};
+use num_bigint::{BigUint, BigInt};
 
 use super::super::Tag;
 use super::*;
@@ -555,7 +555,7 @@ fn test_ber_read_bigint_err() {
 
 #[cfg(feature = "bigint")]
 fn test_general_read_bigint_ok(mode: BERMode) {
-    use num::FromPrimitive;
+    use num_traits::FromPrimitive;
     let tests : &[(i64, &[u8])] = &[
         (-9223372036854775808, &[2, 8, 128, 0, 0, 0, 0, 0, 0, 0]),
         (-65537, &[2, 3, 254, 255, 255]),
@@ -649,7 +649,7 @@ fn test_ber_read_biguint_err() {
 
 #[cfg(feature = "bigint")]
 fn test_general_read_biguint_ok(mode: BERMode) {
-    use num::FromPrimitive;
+    use num_traits::FromPrimitive;
     let tests : &[(u64, &[u8])] = &[
         (0, &[2, 1, 0]),
         (1, &[2, 1, 1]),

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 #[cfg(feature = "bigint")]
-use num::bigint::{BigUint, BigInt};
+use num_bigint::{BigUint, BigInt};
 #[cfg(feature = "bitvec")]
 use bit_vec::BitVec;
 
@@ -314,11 +314,11 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num;
+    /// # extern crate num_bigint;
     /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
-    /// use num::bigint::BigInt;
+    /// use num_bigint::BigInt;
     /// let der = yasna::construct_der(|writer| {
     ///     writer.write_bigint(
     ///         &BigInt::parse_bytes(b"1234567890", 10).unwrap())
@@ -327,7 +327,7 @@ impl<'a> DERWriter<'a> {
     /// # }
     /// ```
     pub fn write_bigint(mut self, val: &BigInt) {
-        use num::bigint::Sign;
+        use num_bigint::Sign;
         self.write_identifier(TAG_INTEGER, PC::Primitive);
         let (sign, mut bytes) = val.to_bytes_le();
         match sign {
@@ -376,11 +376,11 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num;
+    /// # extern crate num_bigint;
     /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
-    /// use num::bigint::BigUint;
+    /// use num_bigint::BigUint;
     /// let der = yasna::construct_der(|writer| {
     ///     writer.write_biguint(
     ///         &BigUint::parse_bytes(b"1234567890", 10).unwrap())

--- a/src/writer/tests.rs
+++ b/src/writer/tests.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 #[cfg(feature = "bigint")]
-use num::bigint::{BigUint, BigInt};
+use num_bigint::{BigUint, BigInt};
 
 use super::super::Tag;
 use super::*;
@@ -206,7 +206,7 @@ fn test_der_write_u8() {
 #[cfg(feature = "bigint")]
 #[test]
 fn test_der_write_bigint() {
-    use num::FromPrimitive;
+    use num_traits::FromPrimitive;
     let tests : &[(i64, &[u8])] = &[
         (-9223372036854775808, &[2, 8, 128, 0, 0, 0, 0, 0, 0, 0]),
         (-65537, &[2, 3, 254, 255, 255]),
@@ -254,7 +254,7 @@ fn test_der_write_bigint() {
 #[cfg(feature = "bigint")]
 #[test]
 fn test_der_write_biguint() {
-    use num::FromPrimitive;
+    use num_traits::FromPrimitive;
     let tests : &[(u64, &[u8])] = &[
         (0, &[2, 1, 0]),
         (1, &[2, 1, 1]),


### PR DESCRIPTION
Before:
```
yasna v0.1.3
├── bit-vec v0.4.3
└── num v0.1.37
    ├── num-bigint v0.1.37
    │   ├── num-integer v0.1.34
    │   │   └── num-traits v0.1.37
    │   ├── num-traits v0.1.37 (*)
    │   ├── rand v0.3.15
    │   │   └── libc v0.2.21
    │   └── rustc-serialize v0.3.23
    ├── num-complex v0.1.37
    │   ├── num-traits v0.1.37 (*)
    │   └── rustc-serialize v0.3.23 (*)
    ├── num-integer v0.1.34 (*)
    ├── num-iter v0.1.33
    │   ├── num-integer v0.1.34 (*)
    │   └── num-traits v0.1.37 (*)
    ├── num-rational v0.1.36
    │   ├── num-bigint v0.1.37 (*)
    │   ├── num-integer v0.1.34 (*)
    │   ├── num-traits v0.1.37 (*)
    │   └── rustc-serialize v0.3.23 (*)
    └── num-traits v0.1.37 (*)
```
After:
```
yasna v0.1.3
├── bit-vec v0.4.3
└── num-bigint v0.1.37
    ├── num-integer v0.1.34
    │   └── num-traits v0.1.37
    └── num-traits v0.1.37 (*)
```