### PR TITLE
update num

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ bitvec = ["bit-vec"]
 [dependencies]
 
 [dependencies.num]
-version = "0.1.32"
-features = ["bigint"]
+version = "0.2.0"
 optional = true
 
 [dependencies.bit-vec]


### PR DESCRIPTION
This commit updates `num` crate used by `yasna.rs.`

I'm trying to build `yasna.rs` for `wasm32-unknown-unknown` target, but it failed due to `rustc-serialize` required by `num-0.1`.
No tests failed after upgrading `num,` and it's now compatible with WASM target.