### PR TITLE
Add MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+  # Minimum supported Rust version.
+  # Please also change README.md if you change this.
+  - 1.16.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ This library is currently specialized for BER (Basic Encoding Rules) and DER (Di
 
 This library is currently specialized for on-memory serialization/deserialization. There are no plans for streaming ones.
 
+## Compatibility
+
+The minimum supported Rust version (MSRV) of `yasna.rs` is Rust 1.16.0.
+
 ## License
 
 This library is distributed under MIT/Apache-2.0 dual license.


### PR DESCRIPTION
This adds a minimum supported Rust version to `.travis.yml`. If at a later point we want to use a newer language feature, we can always increase the version, but we won't accidentially increase it.

* num has an MSRV of 1.15.0
* chrono has an MSRV of 1.13.0
* bit-vec's MSRV is unspecified, but 1.16.0 works