### PR TITLE
Arbitrary DER ser- and deserialization from a TaggedDerValue type

### DIFF
--- a/src/deserializer/mod.rs
+++ b/src/deserializer/mod.rs
@@ -12,7 +12,7 @@ use num_bigint::{BigInt,BigUint};
 use bit_vec::BitVec;
 
 use super::{ASN1Result,BERMode,BERReader,parse_ber_general};
-use super::models::ObjectIdentifier;
+use super::models::{ObjectIdentifier,TaggedDerValue};
 #[cfg(feature = "chrono")]
 use super::models::{UTCTime,GeneralizedTime};
 
@@ -463,5 +463,11 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> BERDecodable
             let t11 = try!(T11::decode_ber(reader.next()));
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11));
         })
+    }
+}
+
+impl BERDecodable for TaggedDerValue  {
+    fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
+        reader.read_tagged_der()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,12 @@ pub use reader::{ASN1Error,ASN1ErrorKind,ASN1Result};
 pub use deserializer::{BERDecodable,decode_ber_general,decode_ber,decode_der};
 pub use serializer::{DEREncodable,encode_der};
 
+/// A value of the ASN.1 primitive/constructed ("P/C") bit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum PCBit {
+    Primitive = 0, Constructed = 1,
+}
+
 /// An ASN.1 tag class, used in [`Tag`][tag].
 ///
 /// [tag]: struct.Tag.html

--- a/src/models/der.rs
+++ b/src/models/der.rs
@@ -1,0 +1,40 @@
+// Copyright 2017 Fortanix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::super::Tag;
+use super::super::tags::TAG_OCTETSTRING;
+
+/// Container for a tag and arbitrary DER value.
+///
+/// When obtained by `BERReader::read_tagged_der` in DER mode,
+/// the reader verifies that the payload is actually valid DER.
+/// When constructed from bytes, the caller is responsible for
+/// providing valid DER.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TaggedDerValue {
+    tag: Tag,
+    value: Vec<u8>,
+}
+
+impl TaggedDerValue {
+    pub fn from_octetstring(bytes: Vec<u8>) -> Self {
+        TaggedDerValue { tag: TAG_OCTETSTRING, value: bytes }
+    }
+
+    pub fn from_tag_and_bytes(tag: Tag, bytes: Vec<u8>) -> Self {
+        TaggedDerValue { tag: tag, value: bytes }
+    }
+
+    pub fn tag(&self) -> Tag {
+        self.tag
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+}

--- a/src/models/der.rs
+++ b/src/models/der.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::super::Tag;
-use super::super::tags::TAG_OCTETSTRING;
+use super::super::{PCBit, Tag};
+use super::super::tags::{TAG_OCTETSTRING, TAG_SEQUENCE, TAG_SET};
 
 /// Container for a tag and arbitrary DER value.
 ///
@@ -18,20 +18,45 @@ use super::super::tags::TAG_OCTETSTRING;
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TaggedDerValue {
     tag: Tag,
+    pcbit: PCBit,
     value: Vec<u8>,
 }
 
 impl TaggedDerValue {
     pub fn from_octetstring(bytes: Vec<u8>) -> Self {
-        TaggedDerValue { tag: TAG_OCTETSTRING, value: bytes }
+        TaggedDerValue {
+            tag: TAG_OCTETSTRING,
+            pcbit: PCBit::Primitive,
+            value: bytes,
+        }
     }
 
     pub fn from_tag_and_bytes(tag: Tag, bytes: Vec<u8>) -> Self {
-        TaggedDerValue { tag: tag, value: bytes }
+        let pcbit = match tag {
+            TAG_SEQUENCE | TAG_SET => PCBit::Constructed,
+            _ => PCBit::Primitive,
+        };
+        TaggedDerValue {
+            tag: tag,
+            pcbit: pcbit,
+            value: bytes,
+        }
+    }
+
+    pub fn from_tag_pc_and_bytes(tag: Tag, pcbit: PCBit, bytes: Vec<u8>) -> Self {
+        TaggedDerValue {
+            tag: tag,
+            pcbit: pcbit,
+            value: bytes,
+        }
     }
 
     pub fn tag(&self) -> Tag {
         self.tag
+    }
+
+    pub fn pcbit(&self) -> PCBit {
+        self.pcbit
     }
 
     pub fn value(&self) -> &[u8] {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -11,7 +11,9 @@
 mod oid;
 #[cfg(feature = "chrono")]
 mod time;
+mod der;
 
 pub use self::oid::ObjectIdentifier;
 #[cfg(feature = "chrono")]
 pub use self::time::{UTCTime,GeneralizedTime};
+pub use self::der::TaggedDerValue;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -14,7 +14,7 @@ use num_bigint::{BigInt,BigUint,Sign};
 #[cfg(feature = "bit-vec")]
 use bit_vec::BitVec;
 
-use super::{Tag,TAG_CLASSES};
+use super::{PCBit,Tag,TAG_CLASSES};
 use super::tags::{TAG_EOC,TAG_BOOLEAN,TAG_INTEGER,TAG_OCTETSTRING};
 use super::tags::{TAG_NULL,TAG_OID,TAG_UTF8STRING,TAG_SEQUENCE,TAG_SET};
 use super::tags::{TAG_NUMERICSTRING,TAG_PRINTABLESTRING,TAG_VISIBLESTRING};
@@ -123,11 +123,6 @@ struct BERReaderImpl<'a> {
     pos: usize,
     mode: BERMode,
     depth: usize,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-enum PCBit {
-    Primitive = 0, Constructed = 1,
 }
 
 const PC_BITS : [PCBit; 2] = [PCBit::Primitive, PCBit::Constructed];
@@ -1507,9 +1502,10 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// assert_eq!(res, TaggedDerValue::from_tag_and_bytes(TAG_OCTETSTRING, b"Hello!".to_vec()));
     /// ```
     pub fn read_tagged_der(self) -> ASN1Result<TaggedDerValue> {
-        let (tag, _pcbit, data_pos) = self.inner.skip_general()?;
-        Ok(TaggedDerValue::from_tag_and_bytes(
+        let (tag, pcbit, data_pos) = self.inner.skip_general()?;
+        Ok(TaggedDerValue::from_tag_pc_and_bytes(
                 tag,
+                pcbit,
                 self.inner.buf[data_pos..self.inner.pos].to_vec()))
     }
 


### PR DESCRIPTION
This partially reverts #9 and replaces it with new functionality. `write_tagged_der` can now set the appropriate PC bit value without having to poke through the abstraction.

cc @aandyl