### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0
+- Increase MSRV to 1.17.0
+- Update to bit-vec 0.6.1
+- Support for reading/writing IA5String, BMPString
+
 # 0.2.1
 
 - Ability to read/write raw DER

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yasna"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Masaki Hara <ackie.h.gmai@gmail.com>"]
 
 description = "ASN.1 library for Rust"


### PR DESCRIPTION
Changes in this release:

- Increase MSRV to 1.17.0 (breaking change)
- Update to bit-vec 0.6.1
- Support for reading/writing IA5String, BMPString