### PR TITLE
Enable optional features in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ include = [
 [features]
 default = []
 
+[package.metadata.docs.rs]
+features = ["num-bigint", "bit-vec", "chrono"]
+
 [dependencies]
 
 [dependencies.num-bigint]


### PR DESCRIPTION
This makes the documentation on docs.rs more useful.