### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+- Support for reading/writing BITSTRING without needing the bit-vec crate
+- Addition of try_{construct_der,construct_der_seq}
+
 # 0.3.0
 - Increase MSRV to 1.17.0
 - Update to bit-vec 0.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yasna"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Masaki Hara <ackie.h.gmai@gmail.com>"]
 
 description = "ASN.1 library for Rust"


### PR DESCRIPTION
Changes in this release:

* Support for reading/writing BITSTRING without needing the `bit-vec` crate
* Addition of `try_{construct_der,construct_der_seq}`
