### PR TITLE
Don't pull in non-required default features of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ optional = true
 [dependencies.chrono]
 version = "0.4"
 optional = true
+default-features = false
+features = ["std"]


### PR DESCRIPTION
This saves a dependency on time 0.1; multiple incompatible
versions of time exist (0.1, 0.2, 0.3 soon) and tend to
cause duplicate dependencies.