### PR TITLE
Fix wrong docs link

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1073,7 +1073,7 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// a [`BERReader`][berreader], from which the contents of the
     /// SEQUENCE OF is read.
     ///
-    /// [berreaderseq]: struct.BERReaderSeq.html
+    /// [berreader]: struct.BERReader.html
     ///
     /// This function doesn't return values. Instead, use mutable values to
     /// maintain read values. `collect_set_of` can be an alternative.


### PR DESCRIPTION
This previously gave a warning when running rustdoc