### PR TITLE
Modernize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         - nightly
         # Minimum supported Rust version.
         # Please also change README.md if you change this.
-        - 1.17.0
+        - 1.31.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         # Please also change README.md if you change this.
         - 1.31.0
 
+    env:
+      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v2
     - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/qnighy/yasna.rs"
 readme = "README.md"
 keywords = ["parser", "serialization"]
 license = "MIT/Apache-2.0"
+edition = "2015"
 include = [
   "src/**/*.rs",
   "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/qnighy/yasna.rs"
 repository = "https://github.com/qnighy/yasna.rs"
 readme = "README.md"
 keywords = ["parser", "serialization"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2015"
 include = [
   "src/**/*.rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["num-bigint", "bit-vec", "chrono"]
 [dependencies]
 
 [dependencies.num-bigint]
-version = "0.2"
+version = "0.4"
 optional = true
 
 [dev-dependencies.num-traits]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/qnighy/yasna.rs"
 readme = "README.md"
 keywords = ["parser", "serialization"]
 license = "MIT OR Apache-2.0"
-edition = "2015"
+edition = "2018"
 include = [
   "src/**/*.rs",
   "Cargo.toml",

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Since this library is at an early stage, the APIs are subject to change. However
 Serialization in DER (Distinguished Encoding Rules) is supported. It can also be used for serialization in BER (Basic Encoding Rules).
 
 ```rust
-extern crate yasna;
-
 fn main() {
     let der = yasna::construct_der(|writer| {
         writer.write_sequence(|writer| {
@@ -49,8 +47,6 @@ These datatypes are *not* supported:
 Deserialization in BER (Basic Encoding Rules) or DER (Distinguished Encoding Rules) is supported.
 
 ```rust
-extern crate yasna;
-
 fn main() {
     let asn = yasna::parse_der(&[48, 6, 2, 1, 10, 1, 1, 255], |reader| {
         reader.read_sequence(|reader| {

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This library is currently specialized for on-memory serialization/deserializatio
 
 ## Compatibility
 
-The minimum supported Rust version (MSRV) of `yasna.rs` is Rust 1.17.0.
+The minimum supported Rust version (MSRV) of `yasna.rs` is Rust 1.31.0.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ extern crate yasna;
 fn main() {
     let asn = yasna::parse_der(&[48, 6, 2, 1, 10, 1, 1, 255], |reader| {
         reader.read_sequence(|reader| {
-            let i = try!(reader.next().read_i64());
-            let b = try!(reader.next().read_bool());
+            let i = reader.next().read_i64()?;
+            let b = reader.next().read_bool()?;
             return Ok((i, b));
         })
     }).unwrap();

--- a/src/deserializer/mod.rs
+++ b/src/deserializer/mod.rs
@@ -67,8 +67,8 @@ pub trait BERDecodable: Sized {
     /// impl BERDecodable for Entry {
     ///     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
     ///         reader.read_sequence(|reader| {
-    ///             let name = try!(reader.next().read_visible_string());
-    ///             let age = try!(reader.next().read_i64());
+    ///             let name = reader.next().read_visible_string()?;
+    ///             let age = reader.next().read_i64()?;
     ///             return Ok(Entry {
     ///                 name: name,
     ///                 age: age,
@@ -141,9 +141,9 @@ impl<T> BERDecodable for Vec<T> where T: BERDecodable {
         reader.read_sequence(|reader| {
             let mut ret = Vec::new();
             loop {
-                let result = try!(reader.read_optional(|reader| {
+                let result = reader.read_optional(|reader| {
                     T::decode_ber(reader)
-                }));
+                })?;
                 match result {
                     Some(result) => {
                         ret.push(result);
@@ -263,7 +263,7 @@ impl<T0> BERDecodable for (T0,)
         where T0: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
             return Ok((t0,));
         })
     }
@@ -273,8 +273,8 @@ impl<T0, T1> BERDecodable for (T0, T1)
         where T0: BERDecodable, T1: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
             return Ok((t0, t1));
         })
     }
@@ -284,9 +284,9 @@ impl<T0, T1, T2> BERDecodable for (T0, T1, T2)
         where T0: BERDecodable, T1: BERDecodable, T2: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
             return Ok((t0, t1, t2));
         })
     }
@@ -297,10 +297,10 @@ impl<T0, T1, T2, T3> BERDecodable for (T0, T1, T2, T3)
             T3: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3));
         })
     }
@@ -311,11 +311,11 @@ impl<T0, T1, T2, T3, T4> BERDecodable for (T0, T1, T2, T3, T4)
             T3: BERDecodable, T4: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4));
         })
     }
@@ -326,12 +326,12 @@ impl<T0, T1, T2, T3, T4, T5> BERDecodable for (T0, T1, T2, T3, T4, T5)
             T3: BERDecodable, T4: BERDecodable, T5: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5));
         })
     }
@@ -343,13 +343,13 @@ impl<T0, T1, T2, T3, T4, T5, T6> BERDecodable for (T0, T1, T2, T3, T4, T5, T6)
             T6: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6));
         })
     }
@@ -362,14 +362,14 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7> BERDecodable
             T6: BERDecodable, T7: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
-            let t7 = try!(T7::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
+            let t7 = T7::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7));
         })
     }
@@ -382,15 +382,15 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8> BERDecodable
             T6: BERDecodable, T7: BERDecodable, T8: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
-            let t7 = try!(T7::decode_ber(reader.next()));
-            let t8 = try!(T8::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
+            let t7 = T7::decode_ber(reader.next())?;
+            let t8 = T8::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7, t8));
         })
     }
@@ -404,16 +404,16 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> BERDecodable
             T9: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
-            let t7 = try!(T7::decode_ber(reader.next()));
-            let t8 = try!(T8::decode_ber(reader.next()));
-            let t9 = try!(T9::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
+            let t7 = T7::decode_ber(reader.next())?;
+            let t8 = T8::decode_ber(reader.next())?;
+            let t9 = T9::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7, t8, t9));
         })
     }
@@ -427,17 +427,17 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> BERDecodable
             T9: BERDecodable, T10: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
-            let t7 = try!(T7::decode_ber(reader.next()));
-            let t8 = try!(T8::decode_ber(reader.next()));
-            let t9 = try!(T9::decode_ber(reader.next()));
-            let t10 = try!(T10::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
+            let t7 = T7::decode_ber(reader.next())?;
+            let t8 = T8::decode_ber(reader.next())?;
+            let t9 = T9::decode_ber(reader.next())?;
+            let t10 = T10::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10));
         })
     }
@@ -451,18 +451,18 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> BERDecodable
             T9: BERDecodable, T10: BERDecodable, T11: BERDecodable {
     fn decode_ber(reader: BERReader) -> ASN1Result<Self> {
         reader.read_sequence(|reader| {
-            let t0 = try!(T0::decode_ber(reader.next()));
-            let t1 = try!(T1::decode_ber(reader.next()));
-            let t2 = try!(T2::decode_ber(reader.next()));
-            let t3 = try!(T3::decode_ber(reader.next()));
-            let t4 = try!(T4::decode_ber(reader.next()));
-            let t5 = try!(T5::decode_ber(reader.next()));
-            let t6 = try!(T6::decode_ber(reader.next()));
-            let t7 = try!(T7::decode_ber(reader.next()));
-            let t8 = try!(T8::decode_ber(reader.next()));
-            let t9 = try!(T9::decode_ber(reader.next()));
-            let t10 = try!(T10::decode_ber(reader.next()));
-            let t11 = try!(T11::decode_ber(reader.next()));
+            let t0 = T0::decode_ber(reader.next())?;
+            let t1 = T1::decode_ber(reader.next())?;
+            let t2 = T2::decode_ber(reader.next())?;
+            let t3 = T3::decode_ber(reader.next())?;
+            let t4 = T4::decode_ber(reader.next())?;
+            let t5 = T5::decode_ber(reader.next())?;
+            let t6 = T6::decode_ber(reader.next())?;
+            let t7 = T7::decode_ber(reader.next())?;
+            let t8 = T8::decode_ber(reader.next())?;
+            let t9 = T9::decode_ber(reader.next())?;
+            let t10 = T10::decode_ber(reader.next())?;
+            let t11 = T11::decode_ber(reader.next())?;
             return Ok((t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11));
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@
 //! [derencodable]: trait.DEREncodable.html
 //!
 //! ```
-//! extern crate yasna;
-//!
 //! fn main() {
 //!     let der = yasna::encode_der(&(10, true));
 //!     println!("(10, true) = {:?}", der);
@@ -31,8 +29,6 @@
 //! [berdecodable]: trait.BERDecodable.html
 //!
 //! ```
-//! extern crate yasna;
-//!
 //! fn main() {
 //!     let asn: (i64, bool) = yasna::decode_der(
 //!         &[48, 6, 2, 1, 10, 1, 1, 255]).unwrap();
@@ -51,8 +47,6 @@
 //! [construct_der]: fn.construct_der.html
 //!
 //! ```
-//! extern crate yasna;
-//!
 //! fn main() {
 //!     let der = yasna::construct_der(|writer| {
 //!         writer.write_sequence(|writer| {
@@ -71,8 +65,6 @@
 //! [parse_der]: fn.parse_der.html
 //!
 //! ```
-//! extern crate yasna;
-//!
 //! fn main() {
 //!     let asn = yasna::parse_der(&[48, 6, 2, 1, 10, 1, 1, 255], |reader| {
 //!         reader.read_sequence(|reader| {
@@ -87,16 +79,6 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-
-#[cfg(feature = "num-bigint")]
-extern crate num_bigint;
-#[cfg(test)]
-extern crate num_traits;
-
-#[cfg(feature = "bit-vec")]
-extern crate bit_vec;
-#[cfg(feature = "chrono")]
-extern crate chrono;
 
 pub mod tags;
 pub mod models;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@
 //! fn main() {
 //!     let asn = yasna::parse_der(&[48, 6, 2, 1, 10, 1, 1, 255], |reader| {
 //!         reader.read_sequence(|reader| {
-//!             let i = try!(reader.next().read_i64());
-//!             let b = try!(reader.next().read_bool());
+//!             let i = reader.next().read_i64()?;
+//!             let b = reader.next().read_bool()?;
 //!             return Ok((i, b));
 //!         })
 //!     }).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,14 +105,14 @@ mod reader;
 mod deserializer;
 mod serializer;
 
-pub use writer::{construct_der,try_construct_der};
-pub use writer::{construct_der_seq,try_construct_der_seq};
-pub use writer::{DERWriter,DERWriterSeq,DERWriterSet};
-pub use reader::{parse_ber_general,parse_ber,parse_der,BERMode};
-pub use reader::{BERReader,BERReaderSeq,BERReaderSet};
-pub use reader::{ASN1Error,ASN1ErrorKind,ASN1Result};
-pub use deserializer::{BERDecodable,decode_ber_general,decode_ber,decode_der};
-pub use serializer::{DEREncodable,encode_der};
+pub use crate::writer::{construct_der,try_construct_der};
+pub use crate::writer::{construct_der_seq,try_construct_der_seq};
+pub use crate::writer::{DERWriter,DERWriterSeq,DERWriterSet};
+pub use crate::reader::{parse_ber_general,parse_ber,parse_der,BERMode};
+pub use crate::reader::{BERReader,BERReaderSeq,BERReaderSet};
+pub use crate::reader::{ASN1Error,ASN1ErrorKind,ASN1Result};
+pub use crate::deserializer::{BERDecodable,decode_ber_general,decode_ber,decode_der};
+pub use crate::serializer::{DEREncodable,encode_der};
 
 /// A value of the ASN.1 primitive/constructed ("P/C") bit.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/src/models/oid.rs
+++ b/src/models/oid.rs
@@ -122,15 +122,11 @@ impl Display for ObjectIdentifier {
 /// An error indicating failure to parse an Object identifier
 pub struct ParseOidError(());
 
-impl Error for ParseOidError {
-    fn description(&self) -> &str {
-        "Failed to parse OID"
-    }
-}
+impl Error for ParseOidError {}
 
 impl Display for ParseOidError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        f.write_str(self.description())
+        f.write_str("Failed to parse OID")
     }
 }
 

--- a/src/models/oid.rs
+++ b/src/models/oid.rs
@@ -108,9 +108,9 @@ impl Display for ObjectIdentifier {
         let mut fst = true;
         for &component in &self.components {
             if fst {
-                try!(write!(f, "{}", component));
+                write!(f, "{}", component)?;
             } else {
-                try!(write!(f, ".{}", component));
+                write!(f, ".{}", component)?;
             }
             fst = false;
         }

--- a/src/models/time.rs
+++ b/src/models/time.rs
@@ -31,8 +31,6 @@ use chrono::{TimeZone,Datelike,Timelike,LocalResult};
 /// # Examples
 ///
 /// ```
-/// # extern crate chrono;
-/// # extern crate yasna;
 /// # fn main() {
 /// use yasna::models::UTCTime;
 /// use chrono::{Datelike,Timelike};
@@ -246,8 +244,6 @@ impl UTCTime {
 /// # Examples
 ///
 /// ```
-/// # extern crate chrono;
-/// # extern crate yasna;
 /// # fn main() {
 /// use yasna::models::GeneralizedTime;
 /// use chrono::{Datelike,Timelike};

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -35,7 +35,7 @@ impl ASN1Error {
 
 impl Display for ASN1Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        try!(write!(f, "{:?}", self));
+        write!(f, "{:?}", self)?;
         return Ok(());
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -667,8 +667,6 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num_bigint;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use num_bigint::BigInt;
@@ -816,8 +814,6 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate bit_vec;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use bit_vec::BitVec;
@@ -852,7 +848,6 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// let data = &[3, 4, 6, 117, 13, 64];

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -25,8 +25,6 @@ use super::models::{ObjectIdentifier,TaggedDerValue};
 use super::models::{UTCTime,GeneralizedTime};
 pub use self::error::*;
 
-use std::ascii::AsciiExt;
-
 /// Parses DER/BER-encoded data.
 ///
 /// [`parse_ber`][parse_ber] and [`parse_der`][parse_der] are shorthands

--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -842,8 +842,8 @@ fn test_der_read_sequence_ok() {
     for &(evalue, data) in tests {
         let value = parse_der(data, |reader| {
             reader.read_sequence(|reader| {
-                let i = try!(reader.next().read_i64());
-                let b = try!(reader.next().read_bool());
+                let i = reader.next().read_i64()?;
+                let b = reader.next().read_bool()?;
                 return Ok((i, b));
             })
         }).unwrap();
@@ -888,8 +888,8 @@ fn test_der_read_sequence_err() {
     for &data in tests {
         parse_der(data, |reader| {
             reader.read_sequence(|reader| {
-                let i = try!(reader.next().read_i64());
-                let b = try!(reader.next().read_bool());
+                let i = reader.next().read_i64()?;
+                let b = reader.next().read_bool()?;
                 return Ok((i, b));
             })
         }).unwrap_err();
@@ -951,8 +951,8 @@ fn test_ber_read_sequence_ok() {
     for &(evalue, ref ervalue, data) in tests {
         let value = parse_ber(data, |reader| {
             reader.read_sequence(|reader| {
-                let i = try!(reader.next().read_i64());
-                let b = try!(reader.next().read_bool());
+                let i = reader.next().read_i64()?;
+                let b = reader.next().read_bool()?;
                 return Ok((i, b));
             })
         }).unwrap();
@@ -998,8 +998,8 @@ fn test_ber_read_sequence_err() {
     for &data in tests {
         parse_ber(data, |reader| {
             reader.read_sequence(|reader| {
-                let i = try!(reader.next().read_i64());
-                let b = try!(reader.next().read_bool());
+                let i = reader.next().read_i64()?;
+                let b = reader.next().read_bool()?;
                 return Ok((i, b));
             })
         }).unwrap_err();
@@ -1016,22 +1016,22 @@ fn test_der_read_set_ok() {
     for &(ref evalue, data) in tests {
         let value = parse_der(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap();
@@ -1075,22 +1075,22 @@ fn test_der_read_set_err() {
     for &data in tests {
         parse_der(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap_err();
@@ -1120,22 +1120,22 @@ fn test_ber_read_set_ok() {
     for &(ref evalue, data) in tests {
         let value = parse_ber(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap();
@@ -1170,22 +1170,22 @@ fn test_ber_read_set_err() {
     for &data in tests {
         parse_ber(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap_err();
@@ -1236,22 +1236,22 @@ fn test_der_read_set_of_err() {
     for &data in tests {
         parse_der(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap_err();
@@ -1308,22 +1308,22 @@ fn test_ber_read_set_of_err() {
     for &data in tests {
         parse_ber(data, |reader| {
             reader.read_set(|reader| {
-                let a = try!(try!(reader.next(&[Tag::context(28)]))
+                let a = reader.next(&[Tag::context(28)])?
                     .read_tagged_implicit(Tag::context(28), |reader| {
                     reader.read_i64()
-                }));
-                let b = try!(try!(reader.next(&[Tag::context(345678)]))
+                })?;
+                let b = reader.next(&[Tag::context(345678)])?
                     .read_tagged(Tag::context(345678), |reader| {
                     reader.read_bytes()
-                }));
-                let c = try!(try!(reader.next(&[Tag::context(27)]))
+                })?;
+                let c = reader.next(&[Tag::context(27)])?
                     .read_tagged(Tag::context(27), |reader| {
                     reader.read_i64()
-                }));
-                let d = try!(try!(reader.next(&[Tag::context(345677)]))
+                })?;
+                let d = reader.next(&[Tag::context(345677)])?
                     .read_tagged(Tag::context(345677), |reader| {
                     reader.read_bytes()
-                }));
+                })?;
                 return Ok((a, b, c, d));
             })
         }).unwrap_err();
@@ -1353,8 +1353,8 @@ fn test_der_read_tagged_ok() {
         let value = parse_der(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1375,8 +1375,8 @@ fn test_der_read_tagged_err() {
         parse_der(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1436,8 +1436,8 @@ fn test_ber_read_tagged_ok() {
         let value = parse_ber(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1457,8 +1457,8 @@ fn test_ber_read_tagged_err() {
         parse_ber(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1513,8 +1513,8 @@ fn test_der_read_tagged_implicit_ok() {
         let value = parse_der(data, |reader| {
             reader.read_tagged_implicit(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1536,8 +1536,8 @@ fn test_der_read_tagged_implicit_err() {
         parse_der(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1596,8 +1596,8 @@ fn test_ber_read_tagged_implicit_ok() {
         let value = parse_ber(data, |reader| {
             reader.read_tagged_implicit(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })
@@ -1619,8 +1619,8 @@ fn test_ber_read_tagged_implicit_err() {
         parse_ber(data, |reader| {
             reader.read_tagged(Tag::context(3), |reader| {
                 reader.read_sequence(|reader| {
-                    let i = try!(reader.next().read_i64());
-                    let b = try!(reader.next().read_bool());
+                    let i = reader.next().read_i64()?;
+                    let b = reader.next().read_bool()?;
                     return Ok((i, b));
                 })
             })

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -424,8 +424,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num_bigint;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use num_bigint::BigInt;
@@ -495,8 +493,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num_bigint;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use num_bigint::BigUint;
@@ -542,8 +538,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate bit_vec;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use bit_vec::BitVec;
@@ -579,7 +573,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// let der_1 = yasna::construct_der(|writer| {
@@ -990,8 +983,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate chrono;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use yasna::models::UTCTime;
@@ -1026,8 +1017,6 @@ impl<'a> DERWriter<'a> {
     /// # Examples
     ///
     /// ```
-    /// # extern crate chrono;
-    /// # extern crate yasna;
     /// # fn main() {
     /// use yasna;
     /// use yasna::models::GeneralizedTime;

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -22,8 +22,6 @@ use super::models::{ObjectIdentifier,TaggedDerValue};
 #[cfg(feature = "chrono")]
 use super::models::{UTCTime,GeneralizedTime};
 
-use std::ascii::AsciiExt;
-
 /// Constructs DER-encoded data as `Vec<u8>`.
 ///
 /// This function uses the loan pattern: `callback` is called back with


### PR DESCRIPTION
Various modernizations of the codebase:

* Update num-bigint dependency to 0.4, requiring MSRV update to 1.31.0
* Increase MSRV to 1.31.0
* Switch edition to 2018
* Migrate from `try!` to ?

In a later pull request, I want to increase the MSRV again to 1.36.0 and adopt usage of the `alloc` crate so that yasna can be made `#![no_std]`