### PR TITLE
Add std feature and add #![no_std]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         - nightly
         # Minimum supported Rust version.
         # Please also change README.md if you change this.
-        - 1.31.0
+        - 1.36.0
 
     env:
       RUSTFLAGS: -D warnings
@@ -29,7 +29,7 @@ jobs:
       run: |
         cargo build --verbose
         cargo test --verbose --no-default-features
-        cargo test --verbose --no-default-features --features="num-bigint bit-vec chrono"
+        cargo test --verbose --no-default-features --features="num-bigint bit-vec chrono std"
         cargo doc --features="num-bigint bit-vec chrono"
       continue-on-error: ${{ matrix.rust == 'nightly' }}
     - name: Deploy to GitHub Pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,10 @@ include = [
 
 [features]
 default = []
+std = []
 
 [package.metadata.docs.rs]
-features = ["num-bigint", "bit-vec", "chrono"]
+features = ["num-bigint", "bit-vec", "chrono", "std"]
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This library is currently specialized for on-memory serialization/deserializatio
 
 ## Compatibility
 
-The minimum supported Rust version (MSRV) of `yasna.rs` is Rust 1.31.0.
+The minimum supported Rust version (MSRV) of `yasna.rs` is Rust 1.36.0.
 
 ## License
 

--- a/src/deserializer/mod.rs
+++ b/src/deserializer/mod.rs
@@ -8,6 +8,9 @@
 
 #![forbid(missing_docs)]
 
+use alloc::vec::Vec;
+use alloc::string::String;
+
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigInt,BigUint};
 #[cfg(feature = "bit-vec")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,11 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+#![no_std]
+
+extern crate alloc;
+#[cfg(any(test, feature = "std"))]
+extern crate std;
 
 pub mod tags;
 pub mod models;

--- a/src/models/der.rs
+++ b/src/models/der.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use alloc::vec::Vec;
 use super::super::{PCBit, Tag};
 use super::super::tags::*;
 
@@ -97,7 +98,7 @@ impl TaggedDerValue {
 
     /// If the value is something string-like, returns it as string.
     pub fn as_str(&self) -> Option<&str> {
-        use std::str::from_utf8;
+        use alloc::str::from_utf8;
 
         match (self.tag, self.pcbit) {
             (TAG_IA5STRING, PCBit::Primitive) => from_utf8(&self.value).ok(),

--- a/src/models/oid.rs
+++ b/src/models/oid.rs
@@ -6,9 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::{self,Display};
+use core::fmt::{self, Display};
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::str::FromStr;
+use alloc::str::FromStr;
+use alloc::vec::Vec;
 
 /// A type that represents object identifiers.
 ///
@@ -122,6 +124,7 @@ impl Display for ObjectIdentifier {
 /// An error indicating failure to parse an Object identifier
 pub struct ParseOidError(());
 
+#[cfg(feature = "std")]
 impl Error for ParseOidError {}
 
 impl Display for ParseOidError {
@@ -156,6 +159,7 @@ impl From<Vec<u64>> for ObjectIdentifier {
 
 #[test]
 fn test_display_oid() {
+    use alloc::format;
     let pkcs1 = ObjectIdentifier::from_slice(&[1, 2, 840, 113549, 1, 1]);
     assert_eq!(format!("{}", pkcs1), "1.2.840.113549.1.1");
 }

--- a/src/models/time.rs
+++ b/src/models/time.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use chrono::{DateTime,FixedOffset,NaiveDate,NaiveTime,NaiveDateTime};
 use chrono::offset::Utc;
 use chrono::{TimeZone,Datelike,Timelike,LocalResult};

--- a/src/reader/error.rs
+++ b/src/reader/error.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::error::Error;
-use std::fmt::{self,Display};
-use std::io;
+#[cfg(feature = "std")]
+use std::{error::Error, io};
+use core::fmt::{self, Display};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct ASN1Error {
@@ -40,6 +40,7 @@ impl Display for ASN1Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for ASN1Error {
     fn description(&self) -> &str {
         match self.kind {
@@ -52,6 +53,7 @@ impl Error for ASN1Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<ASN1Error> for io::Error {
     fn from(e: ASN1Error) -> Self {
         return io::Error::new(io::ErrorKind::InvalidData, e);

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -9,6 +9,10 @@
 
 #![allow(missing_docs)]
 
+use alloc::vec::Vec;
+use alloc::string::String;
+use alloc::borrow::ToOwned;
+
 mod error;
 
 #[cfg(feature = "num-bigint")]

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1363,11 +1363,8 @@ impl<'a, 'b> BERReader<'a, 'b> {
 
             match String::from_utf8(bytes) {
                 Ok(string) => {
-                    for c in string.chars() {
-                        if !c.is_ascii() {
-                            println!("{} is not ascii...", c);
-                            return Err(ASN1Error::new(ASN1ErrorKind::Invalid));
-                        }
+                    if !string.is_ascii() {
+                        return Err(ASN1Error::new(ASN1ErrorKind::Invalid));
                     }
                     Ok(string)
                 }

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -8,6 +8,9 @@
 
 #![forbid(missing_docs)]
 
+use alloc::vec::Vec;
+use alloc::string::String;
+
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigInt,BigUint};
 #[cfg(feature = "bit-vec")]

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -9,6 +9,8 @@
 
 #![forbid(missing_docs)]
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigUint, BigInt};
 #[cfg(feature = "bit-vec")]

--- a/src/writer/tests.rs
+++ b/src/writer/tests.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use alloc::vec;
+
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigUint, BigInt};
 


### PR DESCRIPTION
Most of the crate supports no_std already.
For the few things that need std, we add an std feature
that users can enable manually.

This also increases the MSRV as the
alloc crate got stable only with 1.36.0.