### PR TITLE
Intra-doc-link-ify

### DIFF
--- a/src/deserializer/mod.rs
+++ b/src/deserializer/mod.rs
@@ -37,10 +37,8 @@ use super::models::{UTCTime,GeneralizedTime};
 /// of ASN.1 types can be decoded via default `BERDecodable` implementation.
 ///
 /// If you want to decode ASN.1, you may implement `BERDecodable` for your
-/// own types or use [`parse_der`][parse_der]/[`parse_ber`][parse_ber].
-///
-/// [parse_der]: fn.parse_der.html
-/// [parse_ber]: fn.parse_ber.html
+/// own types or use [`parse_der`](crate::parse_der)/
+/// [`parse_ber`](crate::parse_ber).
 ///
 /// # Default implementations
 ///
@@ -91,11 +89,8 @@ pub trait BERDecodable: Sized {
 
 /// Decodes DER/BER-encoded data.
 ///
-/// [`decode_ber`][decode_ber] and [`decode_der`][decode_der] are shorthands
+/// [`decode_ber`] and [`decode_der`] are shorthands
 /// for this function.
-///
-/// [decode_ber]: fn.decode_ber.html
-/// [decode_der]: fn.decode_der.html
 pub fn decode_ber_general<T:BERDecodable>(src: &[u8], mode: BERMode)
         -> ASN1Result<T> {
     parse_ber_general(src, mode, |reader| {
@@ -106,9 +101,7 @@ pub fn decode_ber_general<T:BERDecodable>(src: &[u8], mode: BERMode)
 /// Reads an ASN.1 value from `&[u8]`.
 ///
 /// If you want to accept only DER-encoded data,
-/// use [`decode_der`][decode_der].
-///
-/// [decode_der]: fn.decode_der.html
+/// use [`decode_der`].
 ///
 /// # Examples
 ///
@@ -124,9 +117,7 @@ pub fn decode_ber<T:BERDecodable>(src: &[u8]) -> ASN1Result<T> {
 /// Reads an ASN.1 value from `&[u8]`.
 ///
 /// If you want to decode BER-encoded data in general,
-/// use [`decode_ber`][decode_ber].
-///
-/// [decode_ber]: fn.decode_ber.html
+/// use [`decode_ber`].
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,7 @@
 //!
 //! ## Encoding/decoding simple data
 //!
-//! A type implementing [`DEREncodable`][derencodable] can be easily encoded:
-//!
-//! [derencodable]: trait.DEREncodable.html
+//! A type implementing [`DEREncodable`] can be easily encoded:
 //!
 //! ```
 //! fn main() {
@@ -23,10 +21,8 @@
 //! }
 //! ```
 //!
-//! Similarly, a type implementing [`BERDecodable`][berdecodable] can be
+//! Similarly, a type implementing [`BERDecodable`] can be
 //! easily decoded:
-//!
-//! [berdecodable]: trait.BERDecodable.html
 //!
 //! ```
 //! fn main() {
@@ -42,9 +38,7 @@
 //! all ASN.1 type. In many cases you have to write your reader/writer
 //! by hand.
 //!
-//! To serialize ASN.1 data, you can use [`construct_der`][construct_der].
-//!
-//! [construct_der]: fn.construct_der.html
+//! To serialize ASN.1 data, you can use [`construct_der`].
 //!
 //! ```
 //! fn main() {
@@ -58,11 +52,7 @@
 //! }
 //! ```
 //!
-//! To deserialize ASN.1 data, you can use [`parse_ber`][parse_ber]
-//! or [`parse_der`][parse_der].
-//!
-//! [parse_ber]: fn.parse_ber.html
-//! [parse_der]: fn.parse_der.html
+//! To deserialize ASN.1 data, you can use [`parse_ber`] or [`parse_der`].
 //!
 //! ```
 //! fn main() {
@@ -110,9 +100,7 @@ pub enum PCBit {
     Constructed = 1,
 }
 
-/// An ASN.1 tag class, used in [`Tag`][tag].
-///
-/// [tag]: struct.Tag.html
+/// An ASN.1 tag class, used in [`Tag`].
 ///
 /// A tag class is one of:
 ///

--- a/src/models/time.rs
+++ b/src/models/time.rs
@@ -17,9 +17,7 @@ use chrono::{TimeZone,Datelike,Timelike,LocalResult};
 /// It doesn't carry timezone information.
 ///
 /// Corresponds to ASN.1 UTCTime type. Often used in conjunction with
-/// [`GeneralizedTime`][generaliedtime].
-///
-/// [generalizedtime]: struct.GeneralizedTime.html
+/// [`GeneralizedTime`].
 ///
 /// # Features
 ///
@@ -230,9 +228,7 @@ impl UTCTime {
 /// It doesn't carry timezone information.
 ///
 /// Corresponds to ASN.1 GeneralizedTime type. Often used in conjunction with
-/// [`UTCTime`][utctime].
-///
-/// [utctime]: struct.UTCTime.html
+/// [`UTCTime`].
 ///
 /// # Features
 ///

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -31,11 +31,8 @@ pub use self::error::*;
 
 /// Parses DER/BER-encoded data.
 ///
-/// [`parse_ber`][parse_ber] and [`parse_der`][parse_der] are shorthands
+/// [`parse_ber`] and [`parse_der`] are shorthands
 /// for this function.
-///
-/// [parse_ber]: fn.parse_ber.html
-/// [parse_der]: fn.parse_der.html
 pub fn parse_ber_general<'a, T, F>(buf: &'a [u8], mode: BERMode, callback: F)
         -> ASN1Result<T>
         where F: for<'b> FnOnce(BERReader<'a, 'b>) -> ASN1Result<T> {
@@ -51,13 +48,9 @@ pub fn parse_ber_general<'a, T, F>(buf: &'a [u8], mode: BERMode, callback: F)
 /// Parses BER-encoded data.
 ///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`BERReader`][berreader], from which the ASN.1 value is read.
+/// a [`BERReader`], from which the ASN.1 value is read.
 ///
-/// [berreader]: struct.BERReader.html
-///
-/// If you want to accept only DER-encoded data, use [`parse_der`][parse_der].
-///
-/// [parse_der]: fn.parse_der.html
+/// If you want to accept only DER-encoded data, use [`parse_der`].
 ///
 /// # Examples
 ///
@@ -82,14 +75,10 @@ pub fn parse_ber<'a, T, F>(buf: &'a [u8], callback: F)
 /// Parses DER-encoded data.
 ///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`BERReader`][berreader], from which the ASN.1 value is read.
-///
-/// [berreader]: struct.BERReader.html
+/// a [`BERReader`], from which the ASN.1 value is read.
 ///
 /// If you want to parse BER-encoded data in general,
-/// use [`parse_ber`][parse_ber].
-///
-/// [parse_ber]: fn.parse_ber.html
+/// use [`parse_ber`].
 ///
 /// # Examples
 ///
@@ -111,10 +100,8 @@ pub fn parse_der<'a, T, F>(buf: &'a [u8], callback: F)
     parse_ber_general(buf, BERMode::Der, callback)
 }
 
-/// Used by [`BERReader`][berreader] to determine whether or not to enforce
+/// Used by [`BERReader`] to determine whether or not to enforce
 /// DER restrictions when parsing.
-///
-/// [berreader]: struct.BERReader.html
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum BERMode {
     /// Use BER (Basic Encoding Rules).
@@ -403,13 +390,9 @@ impl<'a> BERReaderImpl<'a> {
 ///
 /// The two main sources of `BERReaderSeq` are:
 ///
-/// - The [`parse_ber`][parse_ber]/[`parse_der`][parse_der] function,
+/// - The [`parse_ber`]/[`parse_der`] function,
 ///   the starting point of DER serialization.
-/// - The `next` method of [`BERReaderSeq`][berreaderseq].
-///
-/// [parse_ber]: fn.parse_ber.html
-/// [parse_der]: fn.parse_der.html
-/// [berreaderseq]: struct.BERReaderSeq.html
+/// - The `next` method of [`BERReaderSeq`].
 ///
 /// # Examples
 ///
@@ -1031,10 +1014,8 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Reads an ASN.1 SEQUENCE value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReaderSeq`][berreaderseq], from which the contents of the
+    /// a [`BERReaderSeq`], from which the contents of the
     /// SEQUENCE is read.
-    ///
-    /// [berreaderseq]: struct.BERReaderSeq.html
     ///
     /// # Examples
     ///
@@ -1067,10 +1048,8 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Reads an ASN.1 SEQUENCE OF value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReader`][berreader], from which the contents of the
+    /// a [`BERReader`], from which the contents of the
     /// SEQUENCE OF is read.
-    ///
-    /// [berreader]: struct.BERReader.html
     ///
     /// This function doesn't return values. Instead, use mutable values to
     /// maintain read values. `collect_set_of` can be an alternative.
@@ -1107,12 +1086,10 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Collects an ASN.1 SEQUENCE OF value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReader`][berreader], from which the contents of the
+    /// a [`BERReader`], from which the contents of the
     /// SEQUENCE OF is read.
     ///
     /// If you don't like `Vec`, you can use `read_sequence_of` instead.
-    ///
-    /// [berreader]: struct.BERReader.html
     ///
     /// # Examples
     ///
@@ -1140,10 +1117,8 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Reads an ASN.1 SET value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReaderSet`][berreaderset], from which the contents of the
+    /// a [`BERReaderSet`], from which the contents of the
     /// SET are read.
-    ///
-    /// [berreaderset]: struct.BERReaderSet.html
     ///
     /// For SET OF values, use `read_set_of` instead.
     ///
@@ -1207,7 +1182,7 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Reads an ASN.1 SET OF value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReader`][berreader], from which the contents of the
+    /// a [`BERReader`], from which the contents of the
     /// SET OF are read.
     ///
     /// This function doesn't return values. Instead, use mutable values to
@@ -1215,8 +1190,6 @@ impl<'a, 'b> BERReader<'a, 'b> {
     ///
     /// This function doesn't sort the elements. In DER, it is assumed that
     /// the elements occur in an order determined by DER encodings of them.
-    ///
-    /// [berreader]: struct.BERReader.html
     ///
     /// For SET values, use `read_set` instead.
     ///
@@ -1264,15 +1237,13 @@ impl<'a, 'b> BERReader<'a, 'b> {
     /// Collects an ASN.1 SET OF value.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`BERReader`][berreader], from which the contents of the
+    /// a [`BERReader`], from which the contents of the
     /// SET OF is read.
     ///
     /// If you don't like `Vec`, you can use `read_set_of` instead.
     ///
     /// This function doesn't sort the elements. In DER, it is assumed that
     /// the elements occur in an order determined by DER encodings of them.
-    ///
-    /// [berreader]: struct.BERReader.html
     ///
     /// # Examples
     ///
@@ -1638,9 +1609,7 @@ impl<'a, 'b> BERReader<'a, 'b> {
 /// A reader object for a sequence of BER/DER-encoded ASN.1 data.
 ///
 /// The main source of this object is the `read_sequence` method from
-/// [`BERReader`][berreader].
-///
-/// [berreader]: struct.BERReader.html
+/// [`BERReader`].
 ///
 /// # Examples
 ///
@@ -1667,9 +1636,7 @@ impl<'a, 'b> BERReaderSeq<'a, 'b> {
         self.inner.mode
     }
 
-    /// Generates a new [`BERReader`][berreader].
-    ///
-    /// [berreader]: struct.BERReader.html
+    /// Generates a new [`BERReader`].
     pub fn next<'c>(&'c mut self) -> BERReader<'a, 'c> {
         BERReader::new(self.inner)
     }
@@ -1755,9 +1722,7 @@ impl<'a, 'b> BERReaderSeq<'a, 'b> {
 /// A reader object for a set of BER/DER-encoded ASN.1 data.
 ///
 /// The main source of this object is the `read_set` method from
-/// [`BERReader`][berreader].
-///
-/// [berreader]: struct.BERReader.html
+/// [`BERReader`].
 ///
 /// # Examples
 ///
@@ -1786,9 +1751,7 @@ impl<'a, 'b> BERReaderSet<'a, 'b> {
         self.impl_ref.mode
     }
 
-    /// Generates a new [`BERReader`][berreader].
-    ///
-    /// [berreader]: struct.BERReader.html
+    /// Generates a new [`BERReader`].
     ///
     /// This method needs `tag_hint` to determine the position of the data.
     pub fn next<'c>(&'c mut self, tag_hint: &[Tag])

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -37,9 +37,7 @@ use super::models::{UTCTime,GeneralizedTime};
 /// of ASN.1 types can be encoded via default `DEREncodable` implementation.
 ///
 /// If you want to encode ASN.1, you may implement `DEREncodable` for your
-/// own types or use [`construct_der`][construct_der].
-///
-/// [construct_der]: fn.construct_der.html
+/// own types or use [`construct_der`].
 ///
 /// # Default implementations
 ///

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -27,9 +27,7 @@ use super::models::{UTCTime,GeneralizedTime};
 /// Constructs DER-encoded data as `Vec<u8>`.
 ///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`DERWriter`][derwriter], to which the ASN.1 value is written.
-///
-/// [derwriter]: struct.DERWriter.html
+/// a [`DERWriter`], to which the ASN.1 value is written.
 ///
 /// # Examples
 ///
@@ -57,15 +55,11 @@ pub fn construct_der<F>(callback: F) -> Vec<u8>
 
 /// Tries to construct DER-encoded data as `Vec<u8>`.
 ///
-/// Same as [`construct_der`][construct_der], only that it allows
+/// Same as [`construct_der`], only that it allows
 /// returning an error from the passed closure.
 ///
-/// [construct_der]: fn.construct_der.html
-///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`DERWriterSeq`][derwriterseq], to which the ASN.1 values are written.
-///
-/// [derwriterseq]: struct.DERWriterSeq.html
+/// a [`DERWriterSeq`], to which the ASN.1 values are written.
 ///
 /// # Examples
 ///
@@ -103,15 +97,11 @@ pub fn try_construct_der<F, E>(callback: F) -> Result<Vec<u8>, E>
 
 /// Constructs DER-encoded sequence of data as `Vec<u8>`.
 ///
-/// This is similar to [`construct_der`][construct_der], but this function
+/// This is similar to [`construct_der`], but this function
 /// accepts more than one ASN.1 values.
 ///
-/// [construct_der]: fn.construct_der.html
-///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`DERWriterSeq`][derwriterseq], to which the ASN.1 values are written.
-///
-/// [derwriterseq]: struct.DERWriterSeq.html
+/// a [`DERWriterSeq`], to which the ASN.1 values are written.
 ///
 /// # Examples
 ///
@@ -137,15 +127,11 @@ pub fn construct_der_seq<F>(callback: F) -> Vec<u8>
 
 /// Tries to construct a DER-encoded sequence of data as `Vec<u8>`.
 ///
-/// Same as [`construct_der_seq`][construct_der_seq], only that it allows
+/// Same as [`construct_der_seq`], only that it allows
 /// returning an error from the passed closure.
 ///
-/// [construct_der_seq]: fn.construct_der_seq.html
-///
 /// This function uses the loan pattern: `callback` is called back with
-/// a [`DERWriterSeq`][derwriterseq], to which the ASN.1 values are written.
-///
-/// [derwriterseq]: struct.DERWriterSeq.html
+/// a [`DERWriterSeq`], to which the ASN.1 values are written.
 ///
 /// # Examples
 ///
@@ -178,12 +164,9 @@ pub fn try_construct_der_seq<F, E>(callback: F) -> Result<Vec<u8> , E>
 ///
 /// The two main sources of `DERWriterSeq` are:
 ///
-/// - The [`construct_der`][construct_der] function, the starting point of
+/// - The [`construct_der`] function, the starting point of
 ///   DER serialization.
-/// - The `next` method of [`DERWriterSeq`][derwriterseq].
-///
-/// [construct_der]: fn.construct_der.html
-/// [derwriterseq]: struct.DERWriterSeq.html
+/// - The `next` method of [`DERWriterSeq`].
 ///
 /// # Examples
 ///
@@ -776,12 +759,11 @@ impl<'a> DERWriter<'a> {
     /// Writes ASN.1 SEQUENCE.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`DERWriterSeq`][derwriterseq], to which the contents of the
+    /// a [`DERWriterSeq`], to which the contents of the
     /// SEQUENCE is written.
     ///
-    /// [derwriterseq]: struct.DERWriterSeq.html
-    ///
-    /// This is equivalent to `write_sequence_of` in behaviors.
+    /// This is equivalent to [`write_sequence_of`](Self::write_sequence_of)
+    /// in behavior.
     ///
     /// # Examples
     ///
@@ -808,12 +790,11 @@ impl<'a> DERWriter<'a> {
     /// Writes ASN.1 SEQUENCE OF.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`DERWriterSeq`][derwriterseq], to which the contents of the
+    /// a [`DERWriterSeq`], to which the contents of the
     /// SEQUENCE OF are written.
     ///
-    /// [derwriterseq]: struct.DERWriterSeq.html
-    ///
-    /// This is equivalent to `write_sequence` in behaviors.
+    /// This is equivalent to [`write_sequence`](Self::write_sequence) in
+    /// behavior.
     ///
     /// # Examples
     ///
@@ -836,12 +817,10 @@ impl<'a> DERWriter<'a> {
     /// Writes ASN.1 SET.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`DERWriterSet`][derwriterset], to which the contents of the
+    /// a [`DERWriterSet`], to which the contents of the
     /// SET are written.
     ///
-    /// [derwriterset]: struct.DERWriterSet.html
-    ///
-    /// For SET OF values, use `write_set_of` instead.
+    /// For SET OF values, use [`write_set_of`](Self::write_set_of) instead.
     ///
     /// # Examples
     ///
@@ -890,12 +869,10 @@ impl<'a> DERWriter<'a> {
     /// Writes ASN.1 SET OF.
     ///
     /// This function uses the loan pattern: `callback` is called back with
-    /// a [`DERWriterSet`][derwriterset], to which the contents of the
+    /// a [`DERWriterSet`], to which the contents of the
     /// SET OF are written.
     ///
-    /// [derwriterset]: struct.DERWriterSet.html
-    ///
-    /// For SET values, use `write_set` instead.
+    /// For SET values, use [`write_set`](Self::write_set) instead.
     ///
     /// # Examples
     ///
@@ -1175,10 +1152,10 @@ impl<'a> DERWriter<'a> {
 
 /// A writer object that accepts ASN.1 values.
 ///
-/// The main source of this object is the `write_sequence` method from
-/// [`DERWriter`][derwriter].
+/// The main source of this object is the [`write_sequence`][write_sequence]
+/// method from [`DERWriter`].
 ///
-/// [derwriter]: struct.DERWriter.html
+/// [write_sequence]: DERWriter::write_sequence
 ///
 /// # Examples
 ///
@@ -1198,9 +1175,7 @@ pub struct DERWriterSeq<'a> {
 }
 
 impl<'a> DERWriterSeq<'a> {
-    /// Generates a new [`DERWriter`][derwriter].
-    ///
-    /// [derwriter]: struct.DERWriter.html
+    /// Generates a new [`DERWriter`].
     pub fn next<'b>(&'b mut self) -> DERWriter<'b> {
         return DERWriter::from_buf(self.buf);
     }
@@ -1209,9 +1184,7 @@ impl<'a> DERWriterSeq<'a> {
 /// A writer object that accepts ASN.1 values.
 ///
 /// The main source of this object is the `write_set` method from
-/// [`DERWriter`][derwriter].
-///
-/// [derwriter]: struct.DERWriter.html
+/// [`DERWriter`].
 ///
 /// # Examples
 ///
@@ -1231,9 +1204,7 @@ pub struct DERWriterSet<'a> {
 }
 
 impl<'a> DERWriterSet<'a> {
-    /// Generates a new [`DERWriter`][derwriter].
-    ///
-    /// [derwriter]: struct.DERWriter.html
+    /// Generates a new [`DERWriter`].
     pub fn next<'b>(&'b mut self) -> DERWriter<'b> {
         self.bufs.push(Vec::new());
         return DERWriter::from_buf(self.bufs.last_mut().unwrap());


### PR DESCRIPTION
The MSRV of yasna is 1.36.0 and intra-doc-links were only introduced 12 versions later in 1.48, however MSRV only refers to the *minimum* supported Rust version. The links are broken on 1.36.0 but the build still works. I expect most people to run `cargo doc` on latest stable anyways. docs.rs does, as does the yasna CI.