### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.4.0
+
+- Increase MSRV to 1.36.0
+- Switch to Github actions for CI
+- `no_std` support (requiring `alloc`)
+- addition of default-off `std` feature to enable std-related features
+
 # 0.3.2
 
 - Disable default features of chrono (except std), removing dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yasna"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Masaki Hara <ackie.h.gmai@gmail.com>"]
 
 description = "ASN.1 library for Rust"


### PR DESCRIPTION
Changes in this release:

- Increase MSRV to 1.36.0
- Switch to Github actions for CI
- `no_std` support (requiring `alloc`)
- addition of default-off `std` feature to enable std-related features