### PR TITLE
Tighten dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = ["std"]
 optional = true
 
 [dependencies.time]
-version = "0.3"
+version = "0.3.1"
 optional = true
 default-features = false
 features = ["std"]


### PR DESCRIPTION
Ensure things build when resolving dependencies to minimal versions.

Checked with:

    cargo +nightly update -Z minimal-versions; cargo check --all-features
    
