### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1 (2022-12-15)
+
+- Ensure yasna builds with `-Z minimal-versions`
+- Addition of `{read,write}_bigint_bytes`
+
 # 0.5.0 (2022-02-02)
 
 - Fix overflow when reading length

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yasna"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Masaki Hara <ackie.h.gmai@gmail.com>"]
 
 description = "ASN.1 library for Rust"


### PR DESCRIPTION
- Ensure yasna builds with `-Z minimal-versions`
- Addition of `{read,write}_bigint_bytes`