### PR TITLE
write_bigint_bytes: strip leading 0s (and also sometimes leading 255s)

### DIFF
--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -470,6 +470,21 @@ impl<'a> DERWriter<'a> {
     /// # }
     /// ```
     pub fn write_bigint_bytes(mut self, bytes: &[u8], positive: bool) {
+        let mut bytes = bytes;
+
+        // Remove leading zero bytes
+        while bytes.get(0) == Some(&0)  {
+            bytes = &bytes[1..];
+        }
+
+        if !positive {
+            // Remove leading 255 bytes
+            // (the order is important here, [255, 0] should be a fixpoint input)
+            while bytes.len() > 1 && bytes[0] == 255 && bytes.get(1).unwrap_or(&0) & 128 != 0 {
+                bytes = &bytes[1..];
+            }
+        }
+
         self.write_identifier(TAG_INTEGER, PCBit::Primitive);
         if bytes.len() == 0 || bytes[0] == 0 {
             self.write_length(1);


### PR DESCRIPTION
This stripping is required, some parsers don't like these leading numbers.