### PR TITLE
document the different behavior between 64 and 32 bit platforms

### DIFF
--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -1662,5 +1662,8 @@ fn test_ber_read_overflow() {
 
     let err = r.unwrap_err();
 
+    #[cfg(target_pointer_width = "32")]
+    assert_eq!(err.kind(), ASN1ErrorKind::Eof);
+    #[cfg(target_pointer_width = "64")]
     assert_eq!(err.kind(), ASN1ErrorKind::IntegerOverflow);
 }


### PR DESCRIPTION
fixes #72 

I'm not sure I'm super happy about a parser having diverging behavior on 32 and 64 bit platforms, but as it was said in #72 that it was only a bug in the test I thought the best way forward would be to document the behavior in the tests.