### PR TITLE
Ensure license files and README are included in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2018"
 include = [
   "src/**/*.rs",
   "Cargo.toml",
+  "LICENSE-*",
+  "README.md",
 ]
 
 [features]


### PR DESCRIPTION
Both the Apache-2.0 and MIT licenses require that redistributed sources contain a copy of the original license text.

I also added the README to the list of included files. Not having it in the list was inconsistent with the `readme = "README.md"` setting, and the fact that this results in the file being included is not cargo behaviour that is good to rely on.

It would be great if you could publish a new release to crates.io after this lands. Thank you!