### PR TITLE
Update the no_std compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ features = ["num-bigint", "bit-vec", "time", "std"]
 
 [dependencies.num-bigint]
 version = "0.4"
+default-features = false
 optional = true
 
 [dev-dependencies.num-traits]


### PR DESCRIPTION
Support  `yasna = { version = "0.5", default-features = false, features = [ "num-bigint" ]}` no_std compilation.